### PR TITLE
Add baseline prevalence sequence generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project aims to provide tool for estimating malaria incidence and transmiss
 - Helper scripts for sequence creation and model development:
   - `model_exp.py`
   - `sequence_creator.py`
+  - `create_sequences_with_baseline` for including the starting prevalence as a
+    feature during training
 - Custom functions for preprocessing simulation data.
 - Dashboard for estimating incidence and transmission intensities/EIR 'emulator.py'
 
@@ -24,6 +26,8 @@ This project aims to provide tool for estimating malaria incidence and transmiss
 
 3. **Sequence Creation**
    - Processes time-series data to generate input-output pairs suitable for model training, handling padding for initial time steps.
+   - `create_sequences_with_baseline` allows models to learn from the initial
+     prevalence value of each run.
 
 4. **Machine Learning Model**
    - Implements an LSTM-based architecture to predict malaria metrics (`EIR_true`, `incall`) using simulation data.
@@ -36,6 +40,7 @@ project_root/
 │── src/                  # Source code/functions directory
 │   ├── preprocessing.py  # Handles data loading and preprocessing
 │   ├── sequence_creator.py  # Creates birectional sequences of tensors
+│   ├── create_sequences_with_baseline  # Adds initial prevalence as a feature
 │   ├── model_exp.py      # Defines PyTorch model and training
 │   ├── test.py           # Model testing
 │   ├── utils.py          # Utility functions (metrics, visualization, etc.)

--- a/src/sequence_creator.py
+++ b/src/sequence_creator.py
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97dc8b8cd34aced9e76ca966fbe392993b2b2f9a16a6da54584090eee43e8d16
-size 2133
+oid sha256:1773a0bc46dd9bf2018bc5beae03058ce6c12189cd6be343629fc1339121d9ce
+size 3624


### PR DESCRIPTION
## Summary
- support sequences including baseline prevalence via `create_sequences_with_baseline`
- document baseline sequence generation in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b96d1c7b4832098f456ae9b026288