### PR TITLE
Add dual LSTM training example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ project_root/
 https://estimatemalariaparameters.streamlit.app/
 
 ![alt text](<Screenshot (1)-2.png>)
+## Training Two LSTM Models
+
+The script `src/train_dual_models.py` trains two LSTM variants:
+1. **Baseline Model** – uses sequences of ANC prevalence only.
+2. **With Start Prevalence** – includes the run's starting prevalence as a constant feature.
+
+Run `python src/train_dual_models.py --csv <path-to-data>` to train both models and display comparative evaluation plots.

--- a/src/train_dual_models.py
+++ b/src/train_dual_models.py
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f20a611a48fa69f9e41ffe9bb34591b774df5f2e1d1dfc44448eaa3be0c78a2
+size 3328


### PR DESCRIPTION
## Summary
- add `train_dual_models.py` demonstrating how to train two variants
- document new script in README

## Testing
- `python3 -m py_compile src/train_dual_models.py`
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688babe947b883209f19173950fc2e83