### PR TITLE
Add dual-model training utility

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,3 +1,89 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a82cd3c44798f597105d64d19fd958bf5865ab785009a5c76ac1bbfbbb07ba1a
-size 3652
+import numpy as np
+import pandas as pd
+import torch 
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn.metrics import mean_squared_error, r2_score, mean_absolute_error
+
+#Process inferences in batches (avoiding GPU memory issue)
+def predict_in_batches(model, X, batch_size=512, device='cpu'):
+    """Generate model predictions in manageable batches."""
+    model.eval()
+    predictions = []
+    with torch.no_grad():
+        for i in range(0, len(X), batch_size):
+            X_batch = X[i:i + batch_size].to(device)
+            if X_batch.ndim == 2:  # Backwards compatibility with 1-D features
+                X_batch = X_batch.unsqueeze(-1)
+            preds = model(X_batch).cpu().numpy()
+            predictions.append(preds)
+    return np.vstack(predictions)
+
+
+#Function to Plot Evaluation Metrics
+def plot_performance_metrics(results, X_train, y_train, X_eval, y_eval):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    y_train_pred_list = [
+        predict_in_batches(result['model'], X_train, batch_size=512, device=device) for result in results
+    ]
+
+    y_eval_pred_list = [
+        predict_in_batches(result['model'], X_eval, batch_size=512, device=device) for result in results
+    ]
+
+    metrics_data = []
+    for idx, result in enumerate(results):
+        y_train_pred = y_train_pred_list[idx]
+        y_eval_pred = y_eval_pred_list[idx]
+
+        train_r2 = r2_score(y_train, y_train_pred)
+        eval_r2 = r2_score(y_eval, y_eval_pred)
+        train_mse = mean_squared_error(y_train, y_train_pred)
+        eval_mse = mean_squared_error(y_eval, y_eval_pred)
+        train_rmse = np.sqrt(train_mse)
+        eval_rmse = np.sqrt(eval_mse)
+        train_mae = mean_absolute_error(y_train, y_train_pred)
+        eval_mae = mean_absolute_error(y_eval, y_eval_pred)
+
+        metrics_data.append({
+            "Model": result['name'],
+            "Train R²": train_r2, "Eval R²": eval_r2,
+            "Train MSE": train_mse, "Eval MSE": eval_mse,
+            "Train RMSE": train_rmse, "Eval RMSE": eval_rmse,
+            "Train MAE": train_mae, "Eval MAE": eval_mae
+        })
+
+    metrics_df = pd.DataFrame(metrics_data)
+    sns.set_theme(style="whitegrid")
+    fig, axes = plt.subplots(2, 2, figsize=(16, 12))
+
+    # R² Plot with value annotations
+    ax = sns.barplot(data=metrics_df.melt(id_vars="Model", value_vars=["Train R²", "Eval R²"]),
+                     x="Model", y="value", hue="variable", palette="viridis", ax=axes[0, 0])
+    axes[0, 0].set_title("R² Score Comparison:Starting_at_Equilibrium")
+    axes[0, 0].set_ylabel("R² Score")
+    for container in ax.containers:
+        ax.bar_label(container, fmt='%.4f', padding=-25, color='white', fontsize =10)
+
+    # MSE Plot
+    sns.barplot(data=metrics_df.melt(id_vars="Model", value_vars=["Train MSE", "Eval MSE"]),
+                x="Model", y="value", hue="variable", palette="magma", ax=axes[0, 1])
+    axes[0, 1].set_title("Mean Squared Error (MSE) Comparison:Starting_at_Equilibrium")
+    axes[0, 1].set_ylabel("MSE")
+
+    # RMSE Plot
+    sns.barplot(data=metrics_df.melt(id_vars="Model", value_vars=["Train RMSE", "Eval RMSE"]),
+                x="Model", y="value", hue="variable", palette="coolwarm", ax=axes[1, 0])
+    axes[1, 0].set_title("Root Mean Squared Error (RMSE) Comparison:Starting_at_Equilibrium")
+    axes[1, 0].set_ylabel("RMSE")
+
+    # MAE Plot
+    sns.barplot(data=metrics_df.melt(id_vars="Model", value_vars=["Train MAE", "Eval MAE"]),
+                x="Model", y="value", hue="variable", palette="cividis", ax=axes[1, 1])
+    axes[1, 1].set_title("Mean Absolute Error (MAE) Comparison:Starting_at_Equilibrium")
+    axes[1, 1].set_ylabel("MAE")
+
+    fig.tight_layout()
+    plt.savefig("plots/test_prediction/performance_metrics_25000runs_at_Equilibrium.png")
+    plt.show()

--- a/src/train_dual_models.py
+++ b/src/train_dual_models.py
@@ -1,3 +1,128 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f20a611a48fa69f9e41ffe9bb34591b774df5f2e1d1dfc44448eaa3be0c78a2
-size 3328
+import argparse
+import time
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from sklearn.model_selection import train_test_split
+
+from src.preprocessing import process_dataframe
+from src.sequence_creator import create_sequences
+from src.model_exp import LSTMModel
+from src import util, evaluate
+
+
+def create_sequences_with_baseline(data: pd.DataFrame, window_size: int):
+    """Create sequences using ANC prevalence and the run's starting prevalence."""
+    xs, ys = [], []
+    seq_len = 2 * window_size + 1
+    has_targets = {'EIR_true', 'incall'}.issubset(data.columns)
+
+    for run in data['run'].unique():
+        run_df = data[data['run'] == run].reset_index(drop=True)
+        start_prev = run_df.loc[0, 'prev_true']
+        prev_values = run_df['prev_true'].values
+        for i in range(len(run_df) - window_size):
+            if i < window_size:
+                pad = np.repeat(prev_values[0], window_size - i)
+                seq_vals = np.concatenate((pad, prev_values[: i + window_size + 1]))
+            else:
+                seq_vals = prev_values[i - window_size : i + window_size + 1]
+            baseline_feat = np.full(seq_len, start_prev)
+            seq = np.stack((seq_vals, baseline_feat), axis=1)
+            xs.append(seq)
+            if has_targets:
+                ys.append(run_df.loc[i, ['EIR_true', 'incall']].values)
+
+    xs = torch.tensor(np.array(xs, dtype=np.float32))
+    if has_targets:
+        ys = torch.tensor(np.array(ys, dtype=np.float32))
+        return xs, ys
+    return xs, None
+
+
+def train(model, train_loader, eval_loader, epochs=25, lr=1e-3):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    criterion = torch.nn.MSELoss()
+    loss_hist, eval_hist = [], []
+    start = time.time()
+
+    for epoch in range(epochs):
+        model.train()
+        running = 0.0
+        for X, y in train_loader:
+            X, y = X.to(device), y.to(device)
+            optimizer.zero_grad()
+            out = model(X)
+            loss = criterion(out, y)
+            loss.backward()
+            optimizer.step()
+            running += loss.item()
+        loss_hist.append(running / len(train_loader))
+
+        model.eval()
+        val_loss = 0.0
+        with torch.no_grad():
+            for Xv, yv in eval_loader:
+                Xv, yv = Xv.to(device), yv.to(device)
+                val_loss += criterion(model(Xv), yv).item()
+        eval_hist.append(val_loss / len(eval_loader))
+        print(f"Epoch {epoch+1}/{epochs}, Loss: {loss_hist[-1]:.4f}, Eval Loss: {eval_hist[-1]:.4f}")
+
+    duration = time.time() - start
+    return loss_hist, eval_hist, duration
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train baseline and start-prevalence LSTM models")
+    parser.add_argument("--csv", required=True, help="CSV file of simulation output")
+    parser.add_argument("--window", type=int, default=10, help="Sequence window size")
+    parser.add_argument("--epochs", type=int, default=25, help="Training epochs")
+    parser.add_argument("--batch", type=int, default=32, help="Batch size")
+    args = parser.parse_args()
+
+    raw_df = pd.read_csv(args.csv)
+    df = process_dataframe(raw_df)
+
+    log_transform = lambda x: np.log(x + 1e-8)
+    df[['prev_true', 'EIR_true', 'incall']] = df[['prev_true', 'EIR_true', 'incall']].apply(log_transform)
+
+    baseline_X, targets = create_sequences(df, args.window)
+    baseline_X = baseline_X.unsqueeze(-1)
+    start_X, _ = create_sequences_with_baseline(df, args.window)
+
+    idx = np.arange(len(targets))
+    train_idx, val_idx = train_test_split(idx, test_size=0.2, random_state=42, shuffle=True)
+
+    def loaders(X):
+        X_train, X_val = X[train_idx], X[val_idx]
+        y_train, y_val = targets[train_idx], targets[val_idx]
+        train_loader = DataLoader(TensorDataset(X_train, y_train), batch_size=args.batch, shuffle=True)
+        val_loader = DataLoader(TensorDataset(X_val, y_val), batch_size=args.batch, shuffle=False)
+        return train_loader, val_loader, X_train, X_val, y_train, y_val
+
+    bl_train_loader, bl_val_loader, X_tr_b, X_val_b, y_tr, y_val = loaders(baseline_X)
+    sp_train_loader, sp_val_loader, X_tr_s, X_val_s, _, _ = loaders(start_X)
+
+    baseline_model = LSTMModel(input_size=1, architecture=[256, 128, 64, 32])
+    bl_loss, bl_eval, bl_duration = train(baseline_model, bl_train_loader, bl_val_loader, epochs=args.epochs)
+    torch.save(baseline_model.state_dict(), "src/trained_model/baseline_model.pth")
+
+    start_model = LSTMModel(input_size=2, architecture=[256, 128, 64, 32])
+    sp_loss, sp_eval, sp_duration = train(start_model, sp_train_loader, sp_val_loader, epochs=args.epochs)
+    torch.save(start_model.state_dict(), "src/trained_model/start_prev_model.pth")
+
+    results = [
+        {"name": "Baseline", "model": baseline_model, "loss_history": bl_loss, "duration": bl_duration},
+        {"name": "With Start Prev", "model": start_model, "loss_history": sp_loss, "duration": sp_duration},
+    ]
+
+    util.plot_training_metrics(results)
+    util.plot_model_comparison(results)
+    evaluate.plot_performance_metrics(results, X_tr_b.squeeze(-1), y_tr, X_val_b.squeeze(-1), y_val)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `create_sequences_with_baseline` helper and new training logic in `src/train_dual_models.py`
- generalize `predict_in_batches` in `evaluate.py` to handle multi-feature inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bcb8abd2c83209fdda4d6df1740cb