### PR TITLE
Add baseline sequence creator

### DIFF
--- a/src/create_sequences_with_baseline.py
+++ b/src/create_sequences_with_baseline.py
@@ -1,0 +1,51 @@
+import numpy as np
+import torch
+import pandas as pd
+
+
+def create_sequences_with_baseline(data: pd.DataFrame, window_size: int):
+    """Create sequences with baseline prevalence.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        DataFrame containing at least ``prev_true`` and ``run`` columns. Optional
+        target columns ``EIR_true`` and ``incall`` will be returned if present.
+    window_size : int
+        Number of timesteps before and after the centre point to include.
+
+    Returns
+    -------
+    tuple(torch.Tensor, torch.Tensor | None)
+        Sequence tensor of shape ``(n_samples, 2 * window_size + 2)`` including
+        the starting prevalence appended to each sequence and target tensor if
+        target columns exist.
+    """
+
+    xs: list[np.ndarray] = []
+    ys: list[np.ndarray] = []
+    has_targets = {'EIR_true', 'incall'}.issubset(data.columns)
+
+    for run, run_df in data.groupby('run'):
+        run_df = run_df.reset_index(drop=True)
+        baseline = run_df.loc[0, 'prev_true']
+        for i in range(len(run_df) - window_size):
+            if i < window_size:
+                pad = window_size - i
+                first = run_df.loc[0, 'prev_true']
+                left = np.full(pad, first)
+                seq = np.concatenate((left, run_df.loc[0:i + window_size, 'prev_true'].to_numpy()))
+            else:
+                seq = run_df.loc[i - window_size:i + window_size, 'prev_true'].to_numpy()
+            seq_with_base = np.concatenate((seq, [baseline]))
+            xs.append(seq_with_base.astype(np.float32))
+
+            if has_targets:
+                target = run_df.loc[i, ['EIR_true', 'incall']].to_numpy(dtype=np.float32)
+                ys.append(target)
+
+    x_tensor = torch.tensor(np.array(xs, dtype=np.float32))
+    if has_targets:
+        y_tensor = torch.tensor(np.array(ys, dtype=np.float32))
+        return x_tensor, y_tensor
+    return x_tensor, None

--- a/src/train_dual_models.py
+++ b/src/train_dual_models.py
@@ -1,3 +1,60 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f20a611a48fa69f9e41ffe9bb34591b774df5f2e1d1dfc44448eaa3be0c78a2
-size 3328
+import argparse
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from sklearn.model_selection import train_test_split
+
+from src.sequence_creator import create_sequences
+from src.create_sequences_with_baseline import create_sequences_with_baseline
+from src.model_exp import LSTMModel, train_model
+from src.evaluate import plot_performance_metrics
+
+
+def prepare_loaders(X, y, batch_size=512):
+    X_train, X_eval, y_train, y_eval = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+    train_loader = DataLoader(TensorDataset(X_train, y_train), batch_size=batch_size, shuffle=True)
+    eval_loader = DataLoader(TensorDataset(X_eval, y_eval), batch_size=batch_size)
+    return train_loader, eval_loader, X_train, y_train, X_eval, y_eval
+
+
+def main(args):
+    df = pd.read_csv(args.csv)
+    log_transform = lambda x: np.log(x + 1e-8)
+
+    df_scaled = df[['run', 'prev_true', 'EIR_true', 'incall']].copy()
+    df_scaled[['prev_true', 'EIR_true', 'incall']] = df_scaled[['prev_true', 'EIR_true', 'incall']].apply(log_transform)
+
+    X_base, y_base = create_sequences(df_scaled[['prev_true', 'EIR_true', 'incall']], args.window)
+    X_base_loaders = prepare_loaders(X_base, y_base, args.batch)
+
+    X_with_base, y_with_base = create_sequences_with_baseline(df_scaled, args.window)
+    X_with_loaders = prepare_loaders(X_with_base, y_with_base, args.batch)
+
+    model_base = LSTMModel(input_size=1, architecture=[256, 128, 64, 32])
+    model_base, _, _, _ = train_model(
+        model_base, X_base_loaders[0], X_base_loaders[1], "baseline", epochs=args.epochs
+    )
+
+    model_with = LSTMModel(input_size=1, architecture=[256, 128, 64, 32])
+    model_with, _, _, _ = train_model(
+        model_with, X_with_loaders[0], X_with_loaders[1], "with_baseline", epochs=args.epochs
+    )
+
+    results = [
+        {"name": "Baseline", "model": model_base},
+        {"name": "With Start Prev", "model": model_with},
+    ]
+
+    plot_performance_metrics(results, X_base_loaders[2], X_base_loaders[3], X_base_loaders[4], X_base_loaders[5])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--csv", required=True, help="Input CSV file")
+    parser.add_argument("--window", type=int, default=5, help="Half window size for sequences")
+    parser.add_argument("--batch", type=int, default=512, help="Batch size")
+    parser.add_argument("--epochs", type=int, default=25, help="Training epochs")
+    main(parser.parse_args())


### PR DESCRIPTION
## Summary
- implement `create_sequences_with_baseline` for runs
- rewrite `train_dual_models.py` to import and use the new helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688bcb857dec83208cab98df9e409cc1